### PR TITLE
[Fix] Underflow on Active Connections

### DIFF
--- a/src/server/scheduler/scheduler.go
+++ b/src/server/scheduler/scheduler.go
@@ -303,7 +303,10 @@ func (this *Scheduler) HandleOp(op Op) {
 		backend.Stats.ActiveConnections++
 		backend.Stats.TotalConnections++
 	case DecrementConnection:
-		backend.Stats.ActiveConnections--
+		// we should not underflow
+		if backend.Stats.ActiveConnections-1 < backend.Stats.ActiveConnections {
+			backend.Stats.ActiveConnections--
+		}
 	default:
 		log.Warn("Don't know how to handle op ", op.op)
 	}


### PR DESCRIPTION
in some rare cases underflow occurs. I have only ever seen this occur when a backend is removed by consul and then is added back later with the same information. It feels like the Stats are still lingering from before the removal causing the underflow but I am not sure how to either flush or clear the Stats when its re initialized.